### PR TITLE
Feature: Added support for ignoring specific code snippets

### DIFF
--- a/docrunner/models/snippet.py
+++ b/docrunner/models/snippet.py
@@ -1,0 +1,17 @@
+from typing import List
+
+from pydantic import BaseModel
+
+from ..models.snippet_options import SnippetOptions
+
+
+class Snippet(BaseModel):
+    code: str
+    options: SnippetOptions
+
+    @classmethod
+    def new(cls, code: str, decorators: List[str]):
+        return cls(
+            code=code,
+            options=SnippetOptions.from_decorators(decorators)
+        )

--- a/docrunner/models/snippet_options.py
+++ b/docrunner/models/snippet_options.py
@@ -1,0 +1,19 @@
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+
+class SnippetOptions(BaseModel):
+    ignore: Optional[bool] = False
+
+    @classmethod
+    def from_decorators(cls, decorators: List[str]):
+        if len(decorators) == 0:
+            return cls()
+        
+        options = cls()
+        for decorator in decorators:
+            if decorator == '<!--docrunner.ignore-->':
+                options.ignore = True
+        
+        return options

--- a/docrunner/utils/general.py
+++ b/docrunner/utils/general.py
@@ -2,7 +2,7 @@ import typer
 from ..exceptions.base_exception import DocrunnerBaseException
 
 
-def log_exception(exception: DocrunnerBaseException):
+def log_exception(exception: DocrunnerBaseException) -> None:
     typer.echo(
         typer.style(
             exception.get_message(),

--- a/docrunner/utils/language.py
+++ b/docrunner/utils/language.py
@@ -2,7 +2,7 @@ import os
 from typing import List, Optional
 
 from ..models.options import Options
-from ..utils.file import (get_all_markdown_files, get_code_from_markdown,
+from ..utils.file import (get_all_markdown_files, get_snippets_from_markdown,
                           write_file)
 
 LANGUAGE_TO_EXTENSION = {
@@ -76,7 +76,7 @@ def create_language_files(options: Options) -> List[str]:
             )
             return code_filepaths
 
-        code_snippets = get_code_from_markdown(
+        code_snippets = get_snippets_from_markdown(
             language=language,
             markdown_path=markdown_path,
         )
@@ -93,12 +93,12 @@ def create_language_files(options: Options) -> List[str]:
                 filepath = f'{temp_directory_path}/file{i + 1}.{LANGUAGE_TO_EXTENSION[language]}'
                 write_file(
                     filepath=filepath,
-                    lines=code_snippets[i],
+                    lines=code_snippets[i].code,
                     overwrite=True,
                 )
                 code_filepaths.append(filepath)
         else:
-            all_lines = ''.join(code_snippets)
+            all_lines = ''.join([snippet.code for snippet in code_snippets])
             filepath = f'{temp_directory_path}/main.{LANGUAGE_TO_EXTENSION[language]}'
             write_file(
                 filepath=filepath,

--- a/example/docrunner.toml
+++ b/example/docrunner.toml
@@ -1,7 +1,7 @@
 [docrunner]
 language = 'python'
 markdown_paths = [
-    './trial.md',
+    '.',
 ]
 multi_file = false
 recursive = true


### PR DESCRIPTION
- docrunner can now ignore certain code snippets in markdown files if they are prefixed with `<!--docrunner.ignore-->` on the line directly above the code snippet