### PR TITLE
Feature: Added support for custom file names in markdown

### DIFF
--- a/docrunner/models/snippet_options.py
+++ b/docrunner/models/snippet_options.py
@@ -1,3 +1,4 @@
+import re
 from typing import List, Optional
 
 from pydantic import BaseModel
@@ -5,15 +6,22 @@ from pydantic import BaseModel
 
 class SnippetOptions(BaseModel):
     ignore: Optional[bool] = False
+    file_name: Optional[str]
 
     @classmethod
     def from_decorators(cls, decorators: List[str]):
-        if len(decorators) == 0:
-            return cls()
-        
         options = cls()
+
+        if len(decorators) == 0:
+            return options
+
         for decorator in decorators:
-            if decorator == '<!--docrunner.ignore-->':
+            decorator = decorator[4: len(decorator) - 3]
+            if decorator == 'docrunner.ignore':
                 options.ignore = True
+
+            if 'docrunner.file_name' in decorator:
+                file_name = [str(result.replace('"', '')) for result in re.findall('".*"', decorator)][0]
+                options.file_name = file_name
         
         return options

--- a/docrunner/utils/file.py
+++ b/docrunner/utils/file.py
@@ -129,8 +129,15 @@ def get_all_markdown_files(markdown_directory: str, recursive: bool = False) -> 
 
 
 def is_snippet_decorator(string: str) -> bool:
-    # TODO: Implement is_docrunner_decorator
-    return string == '<!--docrunner.ignore-->'
+
+    def is_comment(string: str) -> bool:
+        return string[0: 4] == '<!--' and string[-3:] == '-->'
+    
+    if is_comment(string):
+        if 'docrunner.' in string:
+            return True
+
+    return False
 
 
 def _get_complete_snippet(language: str, lines: List[str], line_number: int) -> str:
@@ -153,6 +160,25 @@ def _get_complete_snippet(language: str, lines: List[str], line_number: int) -> 
     
     return code
 
+
+def _is_any_language_opening(string: str) -> bool:
+    """Returns whether the `string` is a markdown language opening of any of the supported languages
+
+    Parameters
+    ----------
+    string : str
+        The string to be checked
+
+    Returns
+    -------
+    bool
+        Whether the `string` is a markdown language opening of any of the supported languages
+    """
+    for language in LANGUAGE_ABBREV_MAPPING.keys():
+        if string in LANGUAGE_ABBREV_MAPPING[language]:
+            return True
+
+    return False
 
 def get_snippets_from_markdown(
     language: str,
@@ -213,7 +239,7 @@ def get_snippets_from_markdown(
                     last_decorator_line = j
                     snippet_decorators.append(markdown_lines[j])
 
-                elif not is_snippet_decorator(markdown_lines[j]) and markdown_lines[j] not in LANGUAGE_ABBREV_MAPPING[language]:
+                elif not is_snippet_decorator(markdown_lines[j]) and not _is_any_language_opening(markdown_lines[j]):
                     if last_decorator_line == j - 1:
                         comment_warning = DocrunnerWarning(
                             f'Docrunner comment found without code snippet at line {j} in `{markdown_path}`'

--- a/docrunner/utils/language.py
+++ b/docrunner/utils/language.py
@@ -91,6 +91,10 @@ def create_language_files(options: Options) -> List[str]:
         if multi_file:
             for i in range(0, len(code_snippets)):
                 filepath = f'{temp_directory_path}/file{i + 1}.{LANGUAGE_TO_EXTENSION[language]}'
+
+                if code_snippets[i].options.file_name:
+                    filepath = f'{temp_directory_path}/{code_snippets[i].options.file_name}'
+
                 write_file(
                     filepath=filepath,
                     lines=code_snippets[i].code,

--- a/example/docrunner.toml
+++ b/example/docrunner.toml
@@ -3,5 +3,5 @@ language = 'python'
 markdown_paths = [
     '.',
 ]
-multi_file = false
-recursive = true
+multi_file = true
+recursive = false


### PR DESCRIPTION
- Users can now specify custom file names for snippets by prefixing the code snippet with `<!--docrunner.file_name = "filename.py"-->` on the line above the snippet
- The file name that is specified is only used if the `multi_file` option is set to `True`, either through the `docrunner.toml` configuration file or through a cli argument