### PR TITLE
Fixed bug in docrunner file comments

### DIFF
--- a/docrunner/languages/dart.py
+++ b/docrunner/languages/dart.py
@@ -22,7 +22,7 @@ def run_dart(
             options=options,
         )
 
-        for filepath in code_filepaths:
+        for filepath in list(code_filepaths.keys()):
             os.system(f'dart run {filepath}')
 
     except DocrunnerBaseException as error:

--- a/docrunner/languages/javascript.py
+++ b/docrunner/languages/javascript.py
@@ -29,7 +29,7 @@ def run_javascript(
             os.system(startup_command)
             return
 
-        for filepath in code_filepaths:
+        for filepath in list(code_filepaths.keys()):
             os.system(f'node {filepath}')
 
     except DocrunnerBaseException as error:

--- a/docrunner/languages/python.py
+++ b/docrunner/languages/python.py
@@ -29,7 +29,7 @@ def run_python(
             os.system(startup_command)
             return
 
-        for filepath in code_filepaths:
+        for filepath in list(code_filepaths.keys()):
             os.system(f'python {filepath}')
 
     except DocrunnerBaseException as error:

--- a/docrunner/languages/typescript.py
+++ b/docrunner/languages/typescript.py
@@ -46,7 +46,7 @@ def run_typescript(
             os.system(startup_command)
             return
         
-        for filepath in code_filepaths:
+        for filepath in list(code_filepaths.keys()):
             compile_exit_code = compile_typescript(filepath=filepath)
             if compile_exit_code != 0:
                 return

--- a/docrunner/models/options.py
+++ b/docrunner/models/options.py
@@ -90,6 +90,6 @@ class Options(BaseModel):
         })
         write_file(
             filepath='docrunner.toml',
-            lines=configuration_lines,
+            content=configuration_lines,
             overwrite=False
         )

--- a/docrunner/models/snippet_options.py
+++ b/docrunner/models/snippet_options.py
@@ -16,7 +16,7 @@ class SnippetOptions(BaseModel):
             return options
 
         for decorator in decorators:
-            decorator = decorator[4: len(decorator) - 3]
+            decorator = decorator[4: len(decorator) - 3].strip()
             if decorator == 'docrunner.ignore':
                 options.ignore = True
 

--- a/docrunner/utils/general.py
+++ b/docrunner/utils/general.py
@@ -1,3 +1,4 @@
+from typing import Any, Dict, List
 import typer
 from ..exceptions.base_exception import DocrunnerBaseException
 
@@ -9,3 +10,14 @@ def log_exception(exception: DocrunnerBaseException) -> None:
             fg=exception.get_output_color()
         )
     )
+
+def merge_dict_with_additions(dicts: List[Dict[Any, int]]) -> Dict[Any, int]:
+    final_dict = {}
+    for dictionary in dicts:
+        for key in dictionary.keys():
+            if key not in final_dict:
+                final_dict[key] = dictionary[key]
+            else:
+                final_dict[key] += dictionary[key]
+
+    return final_dict


### PR DESCRIPTION
- Fixed bugs in the way docrunner parses comments above snippets
- Fixed bug in the way docrunner handles file comments. Docrunner now **_appends_** to and does not rewrite code files if they are linked to more than once(in more than one code snippet) in a markdown file.
- Fixes #43