### PR TITLE
Error handling and better help for commands(Dart Rewrite)

### DIFF
--- a/bin/commands/run.dart
+++ b/bin/commands/run.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:args/command_runner.dart';
 import 'package:colorize/colorize.dart';
 
+import '../constants/help.dart';
 import '../constants/language_color.dart';
 import '../exceptions/docrunner_error.dart';
 import '../languages/dart.dart';
@@ -20,15 +21,32 @@ class RunCommand extends Command {
       "Runs all code belonging to a specific language within a markdown '.md' file";
 
   RunCommand() {
-    argParser.addOption('language', abbr: 'l');
-    argParser.addOption('markdown-path', abbr: 'm');
-    argParser.addOption('directory-path', abbr: 'd');
-    argParser.addOption('startup-command', abbr: 's');
+    argParser.addOption(
+      'language',
+      abbr: 'l',
+      help: LANGUAGE_HELP,
+    );
+    argParser.addOption(
+      'markdown-path',
+      abbr: 'm',
+      help: MARKDOWN_PATH_HELP,
+    );
+    argParser.addOption(
+      'directory-path',
+      abbr: 'd',
+      help: DIRECTORY_PATH_HELP,
+    );
+    argParser.addOption(
+      'startup-command',
+      abbr: 's',
+      help: STARTUP_COMMAND_HELP,
+    );
 
     argParser.addFlag(
       'multi-file',
       negatable: true,
       abbr: 'f',
+      help: MULTI_FILE_HELP,
     );
   }
 

--- a/bin/constants/help.dart
+++ b/bin/constants/help.dart
@@ -1,0 +1,22 @@
+const LANGUAGE_HELP = """
+The language that will be located and run within your '.md' files
+""";
+
+const MARKDOWN_PATH_HELP = '''
+The path to the markdown file you would like to run code from
+''';
+
+const DIRECTORY_PATH_HELP = '''
+The path to the directory where your code should be stored and run
+You can install dependencies, for example, in this directory
+''';
+
+const STARTUP_COMMAND_HELP = '''
+The command you would like to run in order to run
+your code. Put the command in between quotes "node index.js"
+''';
+
+const MULTI_FILE_HELP = '''
+Whether each snippet (denoted by ```) should be placed and run in a
+different file
+''';

--- a/bin/docrunner.dart
+++ b/bin/docrunner.dart
@@ -9,7 +9,7 @@ import 'constants/version.dart';
 Future<void> main(List<String> args) async {
   final runner = CommandRunner(
     'docrunner',
-    'A command line tool which allows you to run the code in your markdown files to ensure that readers always have access to working code.',
+    '\nA command line tool which allows you to run the code in your markdown files to ensure that readers always have access to working code.',
   );
 
   runner.argParser.addFlag(
@@ -19,14 +19,22 @@ Future<void> main(List<String> args) async {
     help: 'Print the current version of docrunner being run',
   );
 
-  final globalResults = runner.argParser.parse(args);
-  if (globalResults['version'] != null && globalResults['version'] != false) {
-    stdout.writeln('Docrunner version $version');
-    exit(0);
-  }
+  try {
+    runner.addCommand(RunCommand());
+    runner.addCommand(InitCommand());
+    runner.addCommand(VersionCommand());
 
-  runner.addCommand(RunCommand());
-  runner.addCommand(VersionCommand());
-  runner.addCommand(InitCommand());
-  await runner.run(args);
+    final globalResults = runner.parse(args);
+
+    if (globalResults['version'] != null && globalResults['version'] != false) {
+      stdout.writeln('Docrunner version $version');
+      exit(0);
+    }
+
+    await runner.run(args);
+  } on Exception catch (error) {
+    if (error is UsageException) {
+      stderr.writeln(error.toString());
+    }
+  }
 }


### PR DESCRIPTION
- Using `try catch` blocks to handle `UsageException` errors thrown by the `args` dart library when parsing command line arguments
- Added extra help messages for command options in the `docrunner run` command