### PR TITLE
No Run option for docrunner(Dart Rewrite)

### DIFF
--- a/bin/commands/run.dart
+++ b/bin/commands/run.dart
@@ -44,14 +44,15 @@ class RunCommand extends Command {
 
     argParser.addFlag(
       'multi-file',
-      negatable: true,
       abbr: 'f',
+      defaultsTo: null,
+      negatable: false,
       help: MULTI_FILE_HELP,
     );
   }
 
   @override
-  void run() async {
+  Future<void> run() async {
     final arguments = argResults!;
 
     final options = await Options.overrideWithCliArguments(

--- a/bin/models/options.dart
+++ b/bin/models/options.dart
@@ -44,7 +44,8 @@ class Options {
         return null;
       }
 
-      return Options.fromMap(optionsMap);
+      final options = Options.fromMap(optionsMap);
+      return options;
     } on FileSystemException {
       return null;
     }

--- a/bin/models/snippet_options.dart
+++ b/bin/models/snippet_options.dart
@@ -1,10 +1,12 @@
 class SnippetOptions {
   SnippetOptions({
     this.ignore = false,
+    this.noRun = false,
     this.filename,
   });
 
   bool ignore;
+  bool noRun;
   String? filename;
 
   static SnippetOptions fromDecorators(List<String> decorators) {
@@ -17,6 +19,8 @@ class SnippetOptions {
       decorator = decorator.substring(4, decorator.length - 3).trim();
       if (decorator == 'docrunner.ignore') {
         snippetOptions.ignore = true;
+      } else if (decorator == 'docrunner.no_run') {
+        snippetOptions.noRun = true;
       } else if (decorator.contains('docrunner.file_name')) {
         final expression = RegExp(r'".*"');
         final filename = expression

--- a/bin/utils/language.dart
+++ b/bin/utils/language.dart
@@ -49,6 +49,9 @@ Future<Map<String, int>> createLanguageFiles({required Options options}) async {
   // ignore: omit_local_variable_types
   Map<String, int> codeFilepaths = {};
 
+  // ignore: omit_local_variable_types
+  List<String> noRun = [];
+
   for (var markdownPath in markdownPaths) {
     final isDirectory = await Directory(markdownPath).exists();
     if (isDirectory) {
@@ -103,6 +106,10 @@ Future<Map<String, int>> createLanguageFiles({required Options options}) async {
           codeFilepaths[filepath] = 1;
         }
 
+        if (codeSnippets[i].options.noRun) {
+          noRun.add(filepath);
+        }
+
         await writeFile(
           filepath: filepath,
           content: codeSnippets[i].code,
@@ -130,6 +137,10 @@ Future<Map<String, int>> createLanguageFiles({required Options options}) async {
       );
     }
   }
+
+  codeFilepaths.removeWhere((key, value) {
+    return noRun.contains(key);
+  });
 
   return codeFilepaths;
 }

--- a/example/docrunner.toml
+++ b/example/docrunner.toml
@@ -1,5 +1,5 @@
 [docrunner]
-language = 'dart'
+language = 'python'
 markdown_paths = [
     '.',
 ]

--- a/website/docs/comments.md
+++ b/website/docs/comments.md
@@ -26,6 +26,7 @@ You can stack multiple docrunner comments on the same code snippet
 
 ## List of Parsed Comments
 - `<!--docrunner.ignore-->` - Causes docrunner to ignore the code snippet this is attached to
+- `<!--docrunner.no_run-->` - Causes docrunner to write the code snippet to a file but not run it
 - `<!--docrunner.file_name = "file.py"-->` - If the `multi_file` field is set to `True` when running docrunner,
 docrunner will put this code snippet in a file named `file.py`
 Check [here](/docs/configuration#multi_file) for more information about `multi_file`


### PR DESCRIPTION
- Added the `<!--docrunner.no_run-->` option for snippets in markdown files
- This option causes docrunner to write a snippet to a file but not run it
- This comment option only activates when the `multi_file` configuration option and/or flag is set to `true`