### PR TITLE
Added dotenv support as configuration option

### DIFF
--- a/bin/languages/dart.dart
+++ b/bin/languages/dart.dart
@@ -4,13 +4,19 @@ import 'package:process_run/shell.dart';
 
 import '../models/options.dart';
 import '../utils/language.dart';
+import 'package:dotenv/dotenv.dart' as dotenv show env;
 
 Future<void> runDart({required Options options}) async {
   var startupCommand = options.startupCommand;
   var finalExitCode = 0;
-  final shellCommandRunner = Shell(commandVerbose: false, throwOnError: false);
 
   final codeFilepaths = await getLanguageFiles(options: options);
+
+  final shellCommandRunner = Shell(
+    commandVerbose: false,
+    throwOnError: false,
+    environment: dotenv.env,
+  );
 
   if (startupCommand != null) {
     startupCommand = startupCommand.replaceAll('"', '');

--- a/bin/languages/javascript.dart
+++ b/bin/languages/javascript.dart
@@ -4,13 +4,19 @@ import 'package:process_run/shell.dart';
 
 import '../models/options.dart';
 import '../utils/language.dart';
+import 'package:dotenv/dotenv.dart' as dotenv show env;
 
 Future<void> runJavascript({required Options options}) async {
   var startupCommand = options.startupCommand;
   var finalExitCode = 0;
-  final shellCommandRunner = Shell(commandVerbose: false, throwOnError: false);
 
   final codeFilepaths = await getLanguageFiles(options: options);
+
+  final shellCommandRunner = Shell(
+    commandVerbose: false,
+    throwOnError: false,
+    environment: dotenv.env,
+  );
 
   if (startupCommand != null) {
     startupCommand = startupCommand.replaceAll('"', '');

--- a/bin/languages/python.dart
+++ b/bin/languages/python.dart
@@ -4,13 +4,19 @@ import 'package:process_run/shell.dart';
 
 import '../models/options.dart';
 import '../utils/language.dart';
+import 'package:dotenv/dotenv.dart' as dotenv show env;
 
 Future<void> runPython({required Options options}) async {
   var startupCommand = options.startupCommand;
   var finalExitCode = 0;
-  final shellCommandRunner = Shell(commandVerbose: false, throwOnError: false);
 
   final codeFilepaths = await getLanguageFiles(options: options);
+
+  final shellCommandRunner = Shell(
+    commandVerbose: false,
+    throwOnError: false,
+    environment: dotenv.env,
+  );
 
   if (startupCommand != null) {
     startupCommand = startupCommand.replaceAll('"', '');

--- a/bin/languages/typescript.dart
+++ b/bin/languages/typescript.dart
@@ -5,6 +5,7 @@ import 'package:process_run/shell.dart';
 import '../models/options.dart';
 import '../utils/language.dart';
 import '../utils/file.dart';
+import 'package:dotenv/dotenv.dart' as dotenv show env;
 
 Future<ProcessResult> _compileTypescript({required String filepath}) async {
   final directoryPath = File(filepath).parent.absolute.path;
@@ -30,9 +31,14 @@ Future<ProcessResult> _compileTypescript({required String filepath}) async {
 Future<void> runTypescript({required Options options}) async {
   var startupCommand = options.startupCommand;
   var finalExitCode = 0;
-  final shellCommandRunner = Shell(commandVerbose: false);
 
   final codeFilepaths = await getLanguageFiles(options: options);
+
+  final shellCommandRunner = Shell(
+    commandVerbose: false,
+    throwOnError: false,
+    environment: dotenv.env,
+  );
 
   if (startupCommand != null) {
     startupCommand = startupCommand.replaceAll('"', '');

--- a/bin/models/options.dart
+++ b/bin/models/options.dart
@@ -15,6 +15,7 @@ class Options {
     this.multiFile,
     this.startupCommand,
     this.recursive,
+    this.dotenv,
   });
 
   @JsonKey(includeIfNull: false)
@@ -34,6 +35,9 @@ class Options {
 
   @JsonKey(includeIfNull: false)
   bool? recursive;
+
+  @JsonKey(includeIfNull: false)
+  String? dotenv;
 
   static Future<Options?> fromConfigFile(String filePath) async {
     try {
@@ -58,6 +62,7 @@ class Options {
     String? startupCommand,
     bool? multiFile,
     bool? recursive,
+    String? dotenv,
   }) async {
     final options = await Options.fromConfigFile('docrunner.toml');
     if (options != null) {
@@ -84,6 +89,11 @@ class Options {
       if (recursive != null) {
         options.recursive = recursive;
       }
+
+      if (dotenv != null) {
+        options.dotenv = dotenv;
+      }
+
       return options;
     } else {
       final options = Options(

--- a/example/docrunner.toml
+++ b/example/docrunner.toml
@@ -5,3 +5,4 @@ markdown_paths = [
 ]
 multi_file = true
 recursive = true
+dotenv = '.env'

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -162,6 +162,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
+  dotenv:
+    dependency: "direct main"
+    description:
+      name: dotenv
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.0"
   file:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: docrunner
 description: A command line tool which allows you to run the code in your markdown files to ensure that readers always have access to working code.
-version: 1.0.0
+version: 1.2.0
 homepage: https://github.com/DudeBro249/docrunner
 
 environment:
@@ -13,6 +13,7 @@ dependencies:
   toml: ^0.11.0
   args: ^2.1.0 
   process_run: ^0.12.1
+  dotenv: ^3.0.0
 
 
 dev_dependencies:


### PR DESCRIPTION
- Added `dotenv` option to `docrunner.toml` configuration file
- This option allows you to link a `.env` file when running your documentation so your code can access loaded environment variables